### PR TITLE
MAJ Doc. : Protection des dossiers sous Nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Une fois votre hébergement trouvé, envoyez simplement le contenu du fichier t�
 
 **Donnez les permissions d'écriture sur le répertoire "var". Celui-ci contiendra des données générées par l'application: config, fichiers des alertes, cache des flux RSS, etc.**
 
+### Protection du répertoire "var"
+
+L'accès au répertoire "var" est bloqué pour les clients HTTP grâce à un fichier `.htaccess`, l'utilisation d'un serveur autre qu'Apache requiert une configuration additionnelle pour en bloquer l'accès.
+
+* Exemple pour Nginx
+  
+  ```Nginx
+  location /chemin-vers-LBCAlerte/var {
+      deny all;
+  }
+  ```
+
 ## Flux RSS
 
 Effectuez votre recherche sur Leboncoin.fr. Lorsque les résultats vous satisfont, copiez le lien de votre barre d'adresse. Retournez à votre application (onglet RSS) et collez le lien dans le champ.


### PR DESCRIPTION
Pour ceux qui utiliser Nginx, les fichiers .htaccess `Deny from all` ne fonctionnent pas et le dossier `/var` est donc public.

Il faut donc bien penser à protéger ce dossier par une directive Nginx `location` comme suit :

``` Nginx
    location /chemin-vers-LBCAlerte/var {
        deny all;
    }
```

Une variante qui protège également les dossiers `app` et `lib` :

``` Nginx
    location ~ ^/chemin-vers-LBCAlerte/(app|lib|var) {
        deny all;
    }
```

Je propose de rajouter cette information (besoin de protection) et l'exemple Nginx dans la documentation.
