### PR TITLE
Update check.php

### DIFF
--- a/app/mail/scripts/check.php
+++ b/app/mail/scripts/check.php
@@ -97,6 +97,7 @@ class Main
             if ($from = $config->get("mailer", "from", null)) {
                 $this->_mailer->From = $from;
                 $this->_mailer->FromName = $from;
+                $this->_mailer->Sender = $from;
             }
         }
         $this->_mailer->isHTML(true);


### PR DESCRIPTION
Ligne 100 : Si le "Sender" n'est pas positionné, le "return-path" dans le header des emails n'est pas généré à la création du mail. Ce qui a pour effet de laisser le MTA le positionner et la valeur est parfois non conforme (www-data@hostname.localdomain). Ce qui fait parfois refuser l'email par l'antispam du serveur SMTP final (sur @voila.fr par exemple mais pas tt le temps ...). Testé avec succès sur Debian Stable et Old-Stable, mais devrait marcher de partout car la lib class.phpmailer.php le gère très bien.