### PR TITLE
ADD: nombre d'annonces dans un email d'alterte

### DIFF
--- a/app/mail/scripts/check.php
+++ b/app/mail/scripts/check.php
@@ -256,10 +256,15 @@ class Main
                         if (!$error) {
                             if ($alert->group_ads) {
                                 $subject = "Alert LeBonCoin : ".$alert->title;
-                                $message = '<h2>Alerte générée le '.date("d/m/Y H:i", $currentTime).'</h2>
-                                <p>Lien de recherche: <a href="'.htmlspecialchars($alert->url, null, "UTF-8").'">'.htmlspecialchars($alert->url, null, "UTF-8").'</a></p>
-                                <p>Liste des nouvelles annonces :</p><hr /><br />'.
-                                implode("<br /><hr /><br />", $newAds).'<hr /><br />';
+                                if (count($newAds) == 1) {
+                                    $message = '<h2>Alerte générée le '.date("d/m/Y H:i", $currentTime).'</h2>
+                                            <p>Une annonce trouvée :</p><hr /><br />'.
+                                            implode("<br /><hr /><br />", $newAds).'<hr /><br />';
+                                } else {
+                                    $message = '<h2>Alerte générée le '.date("d/m/Y H:i", $currentTime).'</h2>
+                                            <p>Liste des <font size="+3"><font color="#FF0000">'.count($newAds).'</font></font> nouvelles annonces :</p><hr /><br />'.
+                                            implode("<br /><hr /><br />", $newAds).'<hr /><br />';
+                                }
 
                                 $this->_mailer->Subject = $subject;
                                 $this->_mailer->Body = $message;


### PR DESCRIPTION
Ligne 259, 9 lignes : 

Un truc que je patch à la mano moi même par dessus ta release et qui me semble intéressent : afficher, soit l'alerte "normale" s'il n'y a qu'une seule annonce, soit le nombre bien visible d'alertes s'il est supérieur à 1 puis ensuite les alertes.

La raison est simple : sur un smartphone + K9mail par exemple on ne voit pas qu'il y a plusieurs annonces et il arrive de les rater si l'on ne scroll pas systématiquement le mail d'alerte. Et scroller pour rien chaque email avec une seule alerte est aussi TRES énervant pour une feignasse dans mon genre :-).

Patch validé depuis des années, mais je t'engage à le faire "propre" au niveau HTML car c'est pas très élégant comme il est là ... Mais a le mérite d'être autosuffisant sans CSS ;-)