### PR TITLE
Évite un traitement sur les caractères spéciaux de l'URL de la recherche originale

### DIFF
--- a/app/rss/scripts/refresh.php
+++ b/app/rss/scripts/refresh.php
@@ -58,7 +58,7 @@ $feeds->setSelfLink(
     !empty($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on"?"https":"http".
     "://".$_SERVER["HTTP_HOST"].$_SERVER["REQUEST_URI"]
 );
-$feeds->setDescription("Flux RSS de la recherche : ".htmlspecialchars($_GET["url"]));
+$feeds->setDescription("Flux RSS de la recherche : ".$_GET["url"]);
 $feeds->setChannelElement("language", "fr-FR");
 // The date when this feed was lastly updated. The publication date is also set.
 $feeds->setDate(date(DATE_RSS, time()));


### PR DESCRIPTION
L'URL de recherche "LBC" utilisée pour créer le flux RSS est indiquée dans le tag `<description>` mais elle n'est pas utilisable en l'état (copier et coller) car ses caractères spéciaux sont converti en entités HTML (via la fonction `htmlspecialchars()`).
Cette conversion est inutile car l'URL est dans un `<![CDATA[  ]]>`.

Ce commit enlève `htmlspecialchars()` afin que l'URL soit telle quelle dans le flux.

On passe donc de :
```Xml
<description><![CDATA[Flux RSS de la recherche : http://www.leboncoin.fr/annonces/offres/rhone_alpes/?f=a&amp;th=1&amp;q=foobar&amp;it=1]]></description>
```

A :
```Xml
<description><![CDATA[Flux RSS de la recherche : http://www.leboncoin.fr/annonces/offres/rhone_alpes/?f=a&th=1&q=foobar&it=1]]></description>
```