### PR TITLE
Use https to fixed mixed content warnings

### DIFF
--- a/app/admin/views/layout.phtml
+++ b/app/admin/views/layout.phtml
@@ -4,7 +4,7 @@
         <title>Alerte mail pour Leboncoin.fr</title>
         <meta charset="utf-8">
         <meta name="robots" content="none">
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+        <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" href="static/styles.css?v=<?php echo APPLICATION_VERSION; ?>" />
     </head>
     <body>

--- a/app/default/views/layout.phtml
+++ b/app/default/views/layout.phtml
@@ -4,7 +4,7 @@
         <title>Alerte mail pour Leboncoin.fr</title>
         <meta charset="utf-8">
         <meta name="robots" content="none">
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+        <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" href="static/styles.css?v=<?php echo APPLICATION_VERSION; ?>" />
     </head>
     <body>


### PR DESCRIPTION
Quand on expose l'appli en HTTPS, on a des warnings dans le navigateur à cause des polices chargées.