### PR TITLE
Fix for 'Class 'SMTP' not found' error

### DIFF
--- a/app/admin/scripts/mail.php
+++ b/app/admin/scripts/mail.php
@@ -18,7 +18,7 @@ if ($config->hasSection("mailer")) {
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $options = array_merge($options, array_map("trim", $_POST));
     if (isset($_POST["testSMTP"])) {
-        require_once "PHPMailer/class.phpmailer.php";
+        require_once "PHPMailer/PHPMailerAutoload.php";
         $mailer = new PHPMailer($exceptions=true);
         $mailer->setLanguage("fr", DOCUMENT_ROOT."/lib/PHPMailer/language/");
         $mailer->CharSet = "utf-8";


### PR DESCRIPTION
Here's a fix for Issue #40 
I found the fix here : https://github.com/PHPMailer/PHPMailer/issues/113#issuecomment-26033577
It works on my setup (external SMTP server with STARTTLS).