### PR TITLE
Utilisateurs : possibilité de définir un nombre d'alertes (quota) #61

### DIFF
--- a/app/admin/scripts/add-user.php
+++ b/app/admin/scripts/add-user.php
@@ -12,6 +12,11 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     } elseif (empty($_POST["password"]) || $_POST["password"] != $_POST["confirmPassword"]) {
         $errors["confirmPassword"] = "Les deux mots de passe ne correspondent pas.";
     }
+    if (empty($_POST["quota"])) {
+        $errors["quota"] = "Veuillez indiquer un quota.";
+    } else {
+        $user->setQuota(trim((int)$_POST["quota"]));
+    }
     if (empty($errors)) {
         $user->setPassword(sha1($_POST["password"]));
         $userStorage->save($user);

--- a/app/admin/scripts/edit-user.php
+++ b/app/admin/scripts/edit-user.php
@@ -1,0 +1,27 @@
+<?php
+$user = new \App\User\User();
+
+if (!isset($_GET["username"]) || !$user = $userStorage->fetchByUsername($_GET["username"])) {
+    header("LOCATION: ?mod=admin&a=users");
+    exit;
+}
+
+$user_get = trim($_GET["username"]);
+
+
+$errors = array();
+if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    
+    $user->setUsername($user_get);
+
+    if (empty($_POST["quota"])) {
+        $errors["quota"] = "Veuillez indiquer un quota.";
+    } else {
+        $user->setQuota(trim((int)$_POST["quota"]));
+    }
+    if (empty($errors)) {
+        $userStorage->save($user);
+        header("LOCATION: ?mod=admin&a=users");
+        exit;
+    }
+}

--- a/app/admin/views/add-user.phtml
+++ b/app/admin/views/add-user.phtml
@@ -24,6 +24,13 @@
             <p class="error"><?php echo $errors["confirmPassword"]; ?></p>
             <?php endif; ?>
         </dd>
+        <dt><label for="quota">Nombre d'alertes maximum (0 pour illimité)</label></dt>
+        <dd>
+            <input type="text" id="quota" name="quota" value="0"/>
+            <?php if (isset($errors["quota"])) : ?>
+            <p class="error"><?php echo $errors["quota"]; ?></p>
+            <?php endif; ?>
+        </dd>
     </dl>
     <p><input type="submit" value="Enregistrer" />
         | <a href="?mod=admin&amp;a=users">annuler</a></p>

--- a/app/admin/views/edit-user.phtml
+++ b/app/admin/views/edit-user.phtml
@@ -1,0 +1,14 @@
+<form action="" method="post" autocomplete="off">
+    <h2>Modifier l'utilisateur <?php echo $user_get; ?></h2>
+    <dl>
+        <dt><label for="quota">Nombre d'alertes maximum (0 pour illimité)</label></dt>
+        <dd>
+            <input type="text" id="quota" name="quota" value="<?php echo $user->getQuota(); ?>"/>
+            <?php if (isset($errors["quota"])) : ?>
+            <p class="error"><?php echo $errors["quota"]; ?></p>
+            <?php endif; ?>
+        </dd>
+    </dl>
+    <p><input type="submit" value="Enregistrer" />
+        | <a href="?mod=admin&amp;a=users">annuler</a></p>
+</form>

--- a/app/admin/views/users.phtml
+++ b/app/admin/views/users.phtml
@@ -3,6 +3,8 @@
     <thead>
         <tr>
             <th>Nom d'utilisateur</th>
+            <th>Quota</th>
+            <th>&nbsp;</th>
             <th>&nbsp;</th>
         </tr>
     </thead>
@@ -10,6 +12,14 @@
         <?php foreach ($users AS $user) : ?>
         <tr>
             <td><?php echo htmlspecialchars($user->getUsername()); ?></td>
+            <td><?php echo $user->getQuota(); ?></td>
+            <td>
+                <?php if ($user->getUsername() != "admin") : ?>
+                <a href="?mod=admin&amp;a=edit-user&amp;username=<?php echo urlencode($user->getUsername()); ?>">modifier</a>
+                <?php else: ?>
+                -
+                <?php endif; ?>
+            </td>
             <td>
                 <?php if ($user->getUsername() != "admin") : ?>
                 <a href="?mod=admin&amp;a=delete-user&amp;username=<?php echo urlencode($user->getUsername()); ?>">supprimer</a>

--- a/app/mail/scripts/form.php
+++ b/app/mail/scripts/form.php
@@ -1,4 +1,12 @@
 <?php
+$errors = array();
+
+$alerts = $storage->fetchAll();
+$user = $userStorage->fetchByUsername($_SESSION["chekyauth"]["username"]);
+
+if ($user->getQuota() != 0 && count($alerts) >= $user->getQuota())
+    $errors["quota"] = "Vous ne pouvez plus ajouter d'alerte, votre quota est atteint (".$user->getQuota().").";
+
 if (isset($_GET["id"])) {
     $alert = $storage->fetchById($_GET["id"]);
 }
@@ -14,7 +22,7 @@ if (isset($_GET["preurl"])) {
 }
 
 $categoryCollection = new \Lbc\CategoryCollection();
-$errors = array();
+
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     foreach ($_POST AS $name => $value) {

--- a/app/mail/views/form.phtml
+++ b/app/mail/views/form.phtml
@@ -2,6 +2,17 @@
 $alertCategories = $alert->getCategories();
 ?>
 <h2>Création d'une nouvelle alerte</h2>
+
+<?php
+if (isset($errors["quota"]))
+{
+    echo '<p class="error">'.$errors["quota"].'</p>';
+}
+else
+{
+?>
+
+
 <form action="" method="post" class="form-alert">
     <h2>Options obligatoires</h2>
     <dl>
@@ -177,8 +188,6 @@ $alertCategories = $alert->getCategories();
 
 
 
-
-
-
-
-
+<?php
+}
+?>

--- a/app/models/Storage/Db/User.php
+++ b/app/models/Storage/Db/User.php
@@ -26,7 +26,8 @@ class User implements \App\Storage\User
                 ->setPassword($userDb->password)
                 ->setUsername($userDb->username)
                 ->setApiKey($userDb->api_key)
-                ->setRssKey($userDb->rss_key);
+                ->setRssKey($userDb->rss_key)
+                ->setQuota($userDb->quota);
             $this->_loadUserOptions($user, $userDb->options);
             $users[] = $user;
         }
@@ -46,7 +47,8 @@ class User implements \App\Storage\User
                 ->setPassword($userDb->password)
                 ->setUsername($userDb->username)
                 ->setApiKey($userDb->api_key)
-                ->setRssKey($userDb->rss_key);
+                ->setRssKey($userDb->rss_key)
+                ->setQuota($userDb->quota);
             $this->_loadUserOptions($user, $userDb->options);
         }
         return $user;
@@ -94,20 +96,23 @@ class User implements \App\Storage\User
                     `password`,
                     `api_key`,
                     `rss_key`,
-                    `options`
+                    `options`,
+                    `quota`
                 ) VALUES (
                     '".$this->_connection->real_escape_string($user->getUsername())."',
                     '".$this->_connection->real_escape_string($user->getPassword())."',
                     ".$api_key.",
                     ".$rss_key.",
-                    '".$this->_connection->real_escape_string(json_encode($user->getOptions()))."'
+                    '".$this->_connection->real_escape_string(json_encode($user->getOptions()))."',
+                    '".$this->_connection->real_escape_string($user->getQuota())."'
                 )");
         } else {
             $this->_connection->query("UPDATE `".$this->_table."` SET
                 `password` = '".$this->_connection->real_escape_string($user->getPassword())."',
                 `api_key` = ".$api_key.",
                 `rss_key` = ".$rss_key.",
-                `options` = '".$this->_connection->real_escape_string(json_encode($user->getOptions()))."'
+                `options` = '".$this->_connection->real_escape_string(json_encode($user->getOptions()))."',
+                `quota` = ".(int)$user->getQuota()."
             WHERE id = ".$user->getId());
         }
         return $this;

--- a/app/models/User/User.php
+++ b/app/models/User/User.php
@@ -7,6 +7,7 @@ class User
     protected $_id;
     protected $_username;
     protected $_password;
+    protected $_quota;
     protected $_api_key;
     protected $_rss_key;
     protected $_options = array();
@@ -132,6 +133,24 @@ class User
     public function getPassword()
     {
         return $this->_password;
+    }
+
+    /**
+    * @param string $quota
+    * @return User
+    */
+    public function setQuota($quota = 0)
+    {
+        $this->_quota = (int)$quota;
+        return $this;
+    }
+
+    /**
+    * @return string
+    */
+    public function getQuota()
+    {
+        return (int)$this->_quota;
     }
 
     /**


### PR DESCRIPTION
Ajout de la fonctionnalité de quotas d'alertes, qui permet de fixer un nombre maxi d'alertes qu'un utilisateur peut avoir (voir #61).

Cette PR nécessite l'ajout du champ `quota` dans la table `LBC_User` : 

```mysql
ALTER TABLE `LBC_User` ADD `quota` INT(5) NOT NULL DEFAULT '0' , ADD INDEX (`quota`) ;
```

* Affichage du quota dans le tableau des utilisateurs
* Ajout du champ dans le formulaire de création d'un utilisateur
* Création du formulaire d'édition d'un utilisateur (seulement le quota)
* Message d'info lors de la création d'une alerte si le nombre d'alertes de l'utilisateur est >= à son quota